### PR TITLE
Add initial bot code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 .env
 venv/
 __pycache__/
+*.pyc
+.pytest_cache/
+.mypy_cache/
+dist/
+build/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Crypto Trading Bot
+
+This repository contains a simple cryptocurrency trading bot. It is organized with separate folders for source code, unit tests, and documentation.
+
+## Setup
+
+1. Clone the repository.
+2. Create a Python virtual environment and install required dependencies.
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   pip install -r requirements.txt
+   ```
+3. Run the bot with `python src/trading_bot.py` to fetch the latest BTC price.
+ 
+## Project Structure
+
+- `src/` - source code for the trading bot
+- `tests/` - unit tests for validating bot functionality
+- `docs/` (optional) - additional project documentation
+
+## Development Guidelines
+
+- Keep all source code inside the `src/` directory.
+- Place unit tests under the `tests/` directory and use `pytest` for running them.
+- Update documentation in the `docs/` directory when necessary.
+- Follow standard Python coding practices and write clear commit messages.
+- Run tests with `pytest`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pytest

--- a/src/trading_bot.py
+++ b/src/trading_bot.py
@@ -1,0 +1,19 @@
+import requests
+
+
+def get_price(symbol="BTC-USD"):
+    """Fetch the spot price for a given symbol from Coinbase."""
+    url = f"https://api.coinbase.com/v2/prices/{symbol}/spot"
+    response = requests.get(url, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return float(data["data"]["amount"])
+
+
+def main():
+    price = get_price()
+    print(f"Current BTC price in USD: ${price:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_trading_bot.py
+++ b/tests/test_trading_bot.py
@@ -1,0 +1,21 @@
+import os
+import sys
+from unittest.mock import patch, MagicMock
+
+# Allow importing from the src directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.trading_bot import get_price
+
+
+@patch("src.trading_bot.requests.get")
+def test_get_price(mock_get):
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": {"amount": "12345.67"}}
+    mock_response.raise_for_status.return_value = None
+    mock_get.return_value = mock_response
+
+    price = get_price("BTC-USD")
+
+    assert price == 12345.67
+    mock_get.assert_called_once()


### PR DESCRIPTION
## Summary
- implement a minimal trading bot that fetches the BTC spot price
- add unit test covering price retrieval logic
- document how to run the bot and tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68728551af74833197a3e3ac1f7a28c4